### PR TITLE
Send confirmation message to member

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -2,7 +2,12 @@ class OrdersController < ApplicationController
   before_action :check_request, only: :create
 
   def create
-    SaveOrderItemService.call(params)
+    service = SaveOrderItemService.new(params)
+
+    if service.call
+      SlackMessageServices::SendConfirmationMessageToMember.call(service.saved_order_items)
+    end
+
     render status: 200, json: "create"
   end
 

--- a/app/services/save_order_item_service.rb
+++ b/app/services/save_order_item_service.rb
@@ -1,21 +1,39 @@
 class SaveOrderItemService
   LUNCH_CODE = "#happylunch".freeze
+  attr_reader :info, :success, :saved_order_items
 
-  def self.call(info)
-    return unless today_order
-
-    message = info["text"].gsub!(LUNCH_CODE, "").strip
-    numbers = message.split(", ")
-
-    Dish.where(item_number: numbers).each do |dish|
-      order_item = OrderItem.find_or_initialize_by(
-        order: today_order, username: info["user_name"], dish: dish
-      )
-      order_item.save
-    end
+  def initialize(info)
+    @info = info
+    @success = true
+    @saved_order_items = []
   end
 
-  def self.today_order
+  # rubocop:disable MethodLength
+  def call
+    return false unless today_order
+    destroy_old_orders(info["user_name"])
+    begin
+      Dish.where(item_number: item_numbers).each do |dish|
+        order_item = OrderItem.new(order: today_order, username: info["user_name"], dish: dish)
+        @saved_order_items << order_item if order_item.save
+      end
+    rescue ActiveRecord::RecordInvalid
+      success = false
+    end
+    success
+  end
+  # rubocop:enable MethodLength
+
+  def today_order
     Order.today.last
+  end
+
+  def destroy_old_orders(username)
+    OrderItem.where(order: today_order, username: username).destroy_all
+  end
+
+  def item_numbers
+    message = info["text"].gsub!(LUNCH_CODE, "").strip
+    message.split(", ")
   end
 end

--- a/app/services/slack_message_services/send_confirmation_message_to_member.rb
+++ b/app/services/slack_message_services/send_confirmation_message_to_member.rb
@@ -1,0 +1,14 @@
+module SlackMessageServices
+  class SendConfirmationMessageToMember < Base
+    def self.call(order_items)
+      content = format_content(order_items)
+      send_message(content)
+    end
+
+    def self.format_content(order_items)
+      username = "@#{order_items.first.username}"
+      dishes = order_items.map { |item| item.dish.name if item.dish }.compact.uniq
+      "#{username} We received your order: #{dishes.join(', ')}. Thank you for your order!"
+    end
+  end
+end

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -4,15 +4,27 @@ describe OrdersController do
   describe "POST #create" do
     context "when Slack token is valid" do
       it "calls SaveOrderItemService" do
-        expect(SaveOrderItemService).to receive(:call)
+        expect_any_instance_of(SaveOrderItemService).to receive(:call)
 
         post :create, token: ENV["OUTGOING_TOKEN"], text: "#happylunch 1", user_name: "cuongvu"
+      end
+
+      context "when order items are saved successfully" do
+        let(:order_item) { FactoryGirl.create(:order_item) }
+
+        it "calls SlackMessageServices::SendConfirmationMessageToMember" do
+          allow_any_instance_of(SaveOrderItemService).to receive(:call).and_return(true)
+          allow_any_instance_of(SaveOrderItemService).to receive(:saved_order_items).and_return([order_item])
+          expect(SlackMessageServices::SendConfirmationMessageToMember).to receive(:call).with([order_item])
+
+          post :create, token: ENV["OUTGOING_TOKEN"], text: "#happylunch 1", user_name: "cuongvu"
+        end
       end
     end
 
     context "when Slack token is invalid" do
       it "does not call SaveOrderItemService" do
-        expect(SaveOrderItemService).not_to receive(:call)
+        expect_any_instance_of(SaveOrderItemService).not_to receive(:call)
 
         post :create, token: "fake-token", text: "#happylunch 1", user_name: "cuongvu"
       end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,5 +1,9 @@
 FactoryGirl.define do
   factory :order do |f|
     f.description { "This is description" }
+
+    factory :today_order do
+      f.created_at Time.zone.now.beginning_of_day
+    end
   end
 end

--- a/spec/services/save_order_item_service_spec.rb
+++ b/spec/services/save_order_item_service_spec.rb
@@ -1,8 +1,9 @@
 require "rails_helper"
 
 describe SaveOrderItemService do
+  let!(:order) { FactoryGirl.create(:today_order) }
+
   context "with existing items" do
-    let!(:order) { FactoryGirl.create(:order) }
     let(:first_dish) { FactoryGirl.create(:dish) }
     let(:second_dish) { FactoryGirl.create(:dish) }
     let(:third_dish) { FactoryGirl.create(:dish) }
@@ -27,7 +28,7 @@ describe SaveOrderItemService do
       end
 
       it "creates a new order item" do
-        expect { described_class.call(@info) }.to change { OrderItem.count }.by(1)
+        expect { described_class.new(@info).call }.to change { OrderItem.count }.by(1)
       end
     end
 
@@ -51,7 +52,7 @@ describe SaveOrderItemService do
       end
 
       it "creates new order items" do
-        expect { described_class.call(@info) }.to change { OrderItem.count }.by(3)
+        expect { described_class.new(@info).call }.to change { OrderItem.count }.by(3)
       end
     end
   end
@@ -76,7 +77,28 @@ describe SaveOrderItemService do
     end
 
     it "does not save any dishes" do
-      expect { described_class.call(@info) }.not_to change { OrderItem.count }
+      expect { described_class.new(@info).call }.not_to change { OrderItem.count }
     end
+  end
+
+  it "calls #destroy_old_orders" do
+    @info = {
+      "token" => ENV["OUTGOING_TOKEN"],
+      "team_id" => "YOUR_SLACK_TEAM_ID",
+      "team_domain" => "mortgageclub",
+      "service_id" => "SLACK_SERVICE_ID",
+      "channel_id" => "YOUR_SLACK_CHANNEL_ID",
+      "channel_name" => "lunch",
+      "timestamp" => "1451291717.000030",
+      "user_id" => "SLACK_USER_ID",
+      "user_name" => "cuongvu",
+      "text" => "#happylunch 1",
+      "trigger_word" => "#happylunch",
+      "controller" => "lunch",
+      "action" => "order"
+    }
+    expect_any_instance_of(described_class).to receive(:destroy_old_orders)
+
+    described_class.new(@info).call
   end
 end

--- a/spec/services/slack_message_services/send_confirmation_message_to_member_spec.rb
+++ b/spec/services/slack_message_services/send_confirmation_message_to_member_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+describe SlackMessageServices::SendConfirmationMessageToMember do
+  let(:pho) { FactoryGirl.create(:dish, item_number: 1, name: "pho") }
+  let(:order_item) { FactoryGirl.create(:order_item, username: "cuongvu", dish: pho) }
+  let(:message) { "@cuongvu We received your order: pho. Thank you for your order!" }
+
+  describe ".format_content" do
+    it "formats a proper content" do
+      expect(described_class.format_content([order_item])).to eq(message)
+    end
+  end
+
+  describe ".call" do
+    it "calls .format_content" do
+      expect(described_class).to receive(:format_content).with(order_item)
+
+      described_class.call(order_item)
+    end
+
+    it "calls .send_message" do
+      allow(described_class).to receive(:format_content).with(order_item).and_return(message)
+      expect(described_class).to receive(:send_message).with(message)
+
+      described_class.call(order_item)
+    end
+  end
+end


### PR DESCRIPTION
Why:
* when receiving member's order, we should send message to confirm

This change addresses the need by:
* issue #33