### PR TITLE
Fix bug: cannot send confirmation message

### DIFF
--- a/app/services/save_order_item_service.rb
+++ b/app/services/save_order_item_service.rb
@@ -1,6 +1,8 @@
 class SaveOrderItemService
+  attr_reader :info, :saved_order_items
+  attr_accessor :success
+
   LUNCH_CODE = "#happylunch".freeze
-  attr_reader :info, :success, :saved_order_items
 
   def initialize(info)
     @info = info


### PR DESCRIPTION
##### Reason
We set ```success``` as attribute reader (attr_reader) of SaveOrderItemService, so we cannot set ```success = true``` [see more](https://github.com/MortgageClub/HappyLunch/blob/master/app/services/save_order_item_service.rb#L7)

#### Change
We change it to ```attr_accessor``` so we can set value for it.