### PR TITLE
Fix bug: cannot send confirmation message

### DIFF
--- a/app/services/save_order_item_service.rb
+++ b/app/services/save_order_item_service.rb
@@ -1,15 +1,16 @@
 class SaveOrderItemService
+  attr_reader :info, :saved_order_items
+
   LUNCH_CODE = "#happylunch".freeze
-  attr_reader :info, :success, :saved_order_items
 
   def initialize(info)
     @info = info
-    @success = true
     @saved_order_items = []
   end
 
   # rubocop:disable MethodLength
   def call
+    success = true
     return false unless today_order
     destroy_old_orders(info["user_name"])
     begin


### PR DESCRIPTION
#### Change

Don't use `success` as `attr_accessor`. 
#### Consideration

I still figure out why [it](https://github.com/MortgageClub/HappyLunch/blob/master/app/services/save_order_item_service.rb#L21) prevents calling `getter method`. Therefore, this PR just a _hot fix_ :cry: 
